### PR TITLE
Don't quit NERDTree on file open by default!

### DIFF
--- a/data/plugins.yaml
+++ b/data/plugins.yaml
@@ -3,7 +3,7 @@
   brief: Nerdtree
   description: A tree explorer plugin
   syntax: ['" Nerdtree', autocmd vimenter * NERDTree, let NERDTreeShowBookmarks=1,
-           let NERDTreeChDirMode=0, let NERDTreeQuitOnOpen=1,
+           let NERDTreeChDirMode=0, let NERDTreeQuitOnOpen=0,
            let NERDTreeMouseMode=2, let NERDTreeShowHidden=1,
            "let NERDTreeIgnore=['\\.pyc','\\~$','\\.swo$','\\.swp$','\\.git','\\.hg','\\.svn','\\.bzr']",
            let NERDTreeKeepTreeInNewTab=1, "let g:nerdtree_tabs_open_on_gui_startup=0", ' ']


### PR DESCRIPTION
By default, Satchet sets this in the user's .vimrc when NERDTree is included in the bundle:

`NERDTreeQuitOnOpen=1`

This is a confusing default setting for several reasons:
- A new VIM user would be expecting a sidebar that works like a traditional text editor's sidebar, in that it would be persistent
- The NERDTree help triggered by pressing `?` (which is the most easily-accesible help documentation for a new VIM user) does not mention this option, making it confusing as to why it is behaving this way
- Satchet does not mention setting NERDTree to behave this way, making it unexpected even for experienced VIM users

This changes it back to expected behavior by default, while leaving the configuration option as listed so that it's easy to find for those who prefer this behavior. In the future, a "plugin configuration" wizard in Satchet for options like this would be great, but for now, the default options should not be so surprising.
