### PR TITLE
Fix install.sh

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,3 +14,4 @@
 * Thomas Boyt ([@thomasboyt](https://github.com/thomasboyt))
 * Suan-Aik Yeo ([@suan](https://github.com/suan))
 * kelto ([@kelto](https://github.com/kelto))
+* ashemsay ([@ashemsay](https://github.com/ashemsay))

--- a/install.sh
+++ b/install.sh
@@ -6,33 +6,34 @@
 # @usage:
 # Run this script from where the sachet was extracted to
 
+
 # sachet installation variables
 sachet__install_home=~/
 sachet__install_cwd="$(pwd)"
 
 # check if .vimrc already exists
-if [ -f "$sachet__install_home"/.vimrc ]; then
+if [ -f "$sachet__install_home".vimrc ]; then
   echo "Moving your ~/.vimrc to ~/.vimrc.old"
-  mv "$sachet__install_home"/.vimrc "$sachet__install_home"/.vimrc.old
+  mv "$sachet__install_home".vimrc "$sachet__install_home".vimrc.old
 
   echo ".. Successfully moved ~/.vimrc to ~/.vimrc.old"
 fi
 
 echo "Copying sachet's .vimrc to ~/.vimrc"
-cp "$sachet__install_cwd"/vimrc "$sachet__install_home"/.vimrc
+cp "$sachet__install_cwd"/vimrc "$sachet__install_home".vimrc
 
 echo ".. Successfully copied vimrc to ~/.vimrc"
 
 # check if .vim folder already exists
-if [ -d "$sachet__install_home"/.vim ]; then
+if [ -d "$sachet__install_home".vim ]; then
   echo "Moving your ~/.vim/ to ~/.vim.old/"
-  mv "$sachet__install_home"/.vim/ "$sachet__install_home"/.vim.old/
+  mv "$sachet__install_home".vim/ "$sachet__install_home".vim.old/
   
   echo ".. Successfully moved ~/.vim/ to ~/.vim.old/"
 fi
 
 echo "Copying sachet's .vim/ to ~/.vim/"
-cp -r "$sachet__install_cwd"/vim/* "$sachet__install_home"/.vim/
+cp -r "$sachet__install_cwd"/vim/ "$sachet__install_home".vim/
 
 echo ".. Successfully copied vim/ to ~/.vim/"
 

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@
 # @usage:
 # Run this script from where the sachet was extracted to
 
+set -e
 
 # sachet installation variables
 sachet__install_home=~/


### PR DESCRIPTION
A fix and an improvement for install.sh, the vim directory could not be copied, yet the script said that everything went ok. Those commits fix that.
Would even be better to print an error message and roll back already made changes, maybe later
